### PR TITLE
修复 podspec.sources 问题

### DIFF
--- a/ZLPhotoLib.podspec
+++ b/ZLPhotoLib.podspec
@@ -11,7 +11,7 @@ s.platform         = :ios, '6.0'
 s.requires_arc     = true
 
 s.frameworks       = 'AssetsLibrary' , 'AVFoundation', 'MediaPlayer'
-s.source_files     = 'ZLPhotoLib/Classes/*'
+s.source_files     = 'ZLPhotoLib/Classes/**/*'
 s.resource         = "ZLPhotoLib/ZLPhotoLib.bundle"
 
 end


### PR DESCRIPTION
修复在 `cocoapods` 中无法正确下载库内容的问题

在master上的 podspec 文件指向的内容只有 Classes/ 根目录的内容. 所有子目录中的文件都没有被包含
